### PR TITLE
✨feat: 회원 정보 수정 [DRKKO-38]

### DIFF
--- a/src/main/java/com/musicq/musicqdomain/member/domain/Member.java
+++ b/src/main/java/com/musicq/musicqdomain/member/domain/Member.java
@@ -35,7 +35,6 @@ public class Member extends BaseEntity {
     private String nickname;
 
     @Column(nullable = false)
-    @Setter
     private String password;
 
     @Column(nullable = false)
@@ -50,4 +49,11 @@ public class Member extends BaseEntity {
     @Builder.Default
     private Long win_count = 0L;
 
+    public void changesNickname(String nickname){
+        this.nickname = nickname;
+    }
+
+    public void changesPassword(String password){
+        this.password = password;
+    }
 }

--- a/src/main/java/com/musicq/musicqdomain/member/domain/MemberImage.java
+++ b/src/main/java/com/musicq/musicqdomain/member/domain/MemberImage.java
@@ -20,6 +20,19 @@ public class MemberImage extends BaseEntity {
     private String profile_img; // 파일 이름
 
     private String path;
+
     @OneToOne(fetch = FetchType.LAZY)
     private Member member;
+
+    public void changesUuid(String uuid){
+        this.uuid = uuid;
+    }
+
+    public void changesProfile_img(String profile_img){
+        this.profile_img = profile_img;
+    }
+
+    public void changesPath(String path){
+        this.path = path;
+    }
 }

--- a/src/main/java/com/musicq/musicqdomain/member/dto/MemberInfoResDto.java
+++ b/src/main/java/com/musicq/musicqdomain/member/dto/MemberInfoResDto.java
@@ -13,9 +13,6 @@ import lombok.Setter;
 @Builder
 public class MemberInfoResDto {
     @NotNull
-    @Setter
-    private long member_id;
-    @NotNull
     private String id;
 
     @NotNull
@@ -23,10 +20,6 @@ public class MemberInfoResDto {
 
     @NotNull
     private String nickname;
-
-    @NotNull
-    @Setter
-    private String password;
 
     @NotNull
     private long record;

--- a/src/main/java/com/musicq/musicqdomain/member/persistence/MemberRepository.java
+++ b/src/main/java/com/musicq/musicqdomain/member/persistence/MemberRepository.java
@@ -6,6 +6,8 @@ import com.musicq.musicqdomain.member.dto.MemberImageDto;
 import com.musicq.musicqdomain.member.dto.MemberInfoResDto;
 import org.json.JSONObject;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +20,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     long countByEmail(String email);
 
     // nickname 존재 여부
-    long countByNickname(String nickname);
+    String countByNickname(String nickname);
+
+    // 본인 nickname 을 변경하지 않고 바로 입력할 때 비교할 nickname 값이 필요하다.
+    @Query("select m.nickname from Member m where m.id = :id")
+    String getCurrentNickname(@Param("id") String id);
 
     // 회원 정보 조회
     Member findById(String id);
@@ -36,11 +42,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
         entityMap.put("member", memberDomain);
 
-        JSONObject memberImageInfo = memberInfo.getJSONObject("memberImageDto");
+        JSONObject memberImageInfo = memberInfo.getJSONObject("memberImage");
 
         MemberImage memberImageDomain = MemberImage.builder()
-                //TODO 추 후 Service Application 에서 UUID 생성하면 주석제거
-                //.uuid(memberImageInfo.getString("uuid"))
+                .uuid(memberImageInfo.getString("uuid"))
                 .path(memberImageInfo.getString("path"))
                 .profile_img(memberImageInfo.getString("profile_img"))
                 .member(memberDomain)
@@ -59,11 +64,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                 .build();
 
         MemberInfoResDto memberInfoResDto = MemberInfoResDto.builder()
-                .member_id(memberDomain.getMemberId())
                 .id(memberDomain.getId())
                 .email(memberDomain.getEmail())
                 .nickname(memberDomain.getNickname())
-                .password(memberDomain.getPassword())
                 .record(memberDomain.getRecord())
                 .games_count(memberDomain.getGames_count())
                 .win_count(memberDomain.getWin_count())


### PR DESCRIPTION
[✨feat: 회원 정보 수정](https://dreamkakao.atlassian.net/jira/software/projects/DRKKO/boards/1/backlog?selectedIssue=DRKKO-38)

1. 변경이 가능한 Entity의 요소 중 회원정보 수정 중 변경이 가능한 요소에서 setter를 제거하고 changes요소명 인 생성자 메서드를 생성해서 변경
2. 회원 정보 수정 중 비밀번호 수정은 분리. (지라에 일감 추가 후, 브랜치 생성하고 작업할 예정)
3. 닉네임 Count 만을 반환하던 Domain 단의 처리를 현재 사용자의 id에 해당하는 nickname과 그 count를 반환하도록 변경
4. 3을 위해서 현재 id를 기반으로 nickname을 DB에서 가져오는 메서드 추가.

[DRKKO-38]: https://dreamkakao.atlassian.net/browse/DRKKO-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ